### PR TITLE
Use @id instead of id for manifest IRIs

### DIFF
--- a/collection-manifest-producer.py
+++ b/collection-manifest-producer.py
@@ -65,7 +65,7 @@ def create_collection(collection_data, host_id, collection_id, starting_record, 
         manifest = {}
         item_id = rec['pointer']
         # TODO: Test the resulting Manifest URI to make sure it exists
-        manifest['id'] = 'https://' + host_id + '.contentdm.oclc.org/digital/iiif-info/' + collection_id + '/' + str(item_id) + '/manifest.json'
+        manifest['@id'] = 'https://' + host_id + '.contentdm.oclc.org/digital/iiif-info/' + collection_id + '/' + str(item_id) + '/manifest.json'
         manifest['label'] = rec['title']
         manifest['@type'] = 'sc:Manifest'
         collection_blob['manifests'].append(manifest)


### PR DESCRIPTION
This fixes a bug in the manifest listing, so that IIIF presentation clients walking the collection can access manifests.